### PR TITLE
global: defaut record template

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -108,7 +108,14 @@ def records():
         pid1 = PersistentIdentifier.create(
             'recid', '1', object_type='rec', object_uuid=rec1_uuid,
             status=PIDStatus.REGISTERED)
-        Record.create({'title': 'Registered '}, id_=rec1_uuid)
+        Record.create({
+            'title': 'Registered ',
+            'authors': [
+                {'name': 'Ellis Jonathan'},
+                {'name': 'Higgs Peter'},
+            ],
+            'keywords': ['CERN', 'higgs'],
+        }, id_=rec1_uuid)
 
         # Record 2 - Deleted PID with record
         rec2_uuid = uuid.uuid4()

--- a/invenio_records_ui/templates/invenio_records_ui/base.html
+++ b/invenio_records_ui/templates/invenio_records_ui/base.html
@@ -1,3 +1,27 @@
+{# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015, 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+-#}
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/invenio_records_ui/templates/invenio_records_ui/detail.html
+++ b/invenio_records_ui/templates/invenio_records_ui/detail.html
@@ -1,7 +1,73 @@
+{# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015, 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+-#}
 {%- extends config.RECORDS_UI_BASE_TEMPLATE %}
 
+{%- macro record_content(data) %}
+  {% for key, value in data.items() recursive %}
+    <li class="list-group-item">
+    {% if value is mapping %}
+        <strong>{{ key }}:</strong>
+        <ul class="list-group">{{ loop(value.items()) }}</ul>
+    {% elif value is iterable and value is not string %}
+        <strong>{{ key }}:</strong>
+        <ol>
+        {% for item in value %}
+          <li>
+          {% if item is mapping %}
+            <ul class="list-group">
+              {{ record_content(item) }}
+            </ul>
+          {% else %}
+            {{ item }}
+          {% endif %}
+          </li>
+        {% endfor %}
+        </ol>
+    {% else %}
+      <strong>{{ key }}:</strong> {{ value }}
+    {% endif %}
+    </li>
+  {% endfor %}
+{%- endmacro %}
+
 {%- block page_body %}
-{{record.title}}
-{{pid.pid_value}}
+<div class="container">
+  {%- block record_title %}
+  <h2>
+    <small>{{ pid.pid_type }}</small> {{pid.pid_value}}
+  </h2>
+  {%- endblock %}
+  {%- block record_body %}
+  {% if record %}
+  <div class="panel panel-default">
+    <ul class="list-group">
+      {{ record_content(record) }}
+    </ul>
+  </div>
+  {% endif %}
+  {%- endblock %}
+</div>
 {%- endblock %}
 

--- a/invenio_records_ui/templates/invenio_records_ui/tombstone.html
+++ b/invenio_records_ui/templates/invenio_records_ui/tombstone.html
@@ -1,7 +1,31 @@
-{%- extends config.RECORDS_UI_BASE_TEMPLATE %}
+{# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015, 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+-#}
+{%- extends "invenio_records_ui/detail.html" %}
 
-{%- block page_body %}
-TOMBSTONE
-{{record.title}}
-{{pid.pid_value}}
+{%- block record_title %}
+<h2>
+  TOMBSTONE <small>{{ pid.pid_type }}</small> {{pid.pid_value}}
+</h2>
 {%- endblock %}


### PR DESCRIPTION
* BETTER Displays all record metadata in default detailed template.
  (closes #2)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>