### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Records-UI.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-records-ui
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/examples/permsapp.py
+++ b/examples/permsapp.py
@@ -40,12 +40,12 @@ Try to view record 1::
 
    http://localhost:5000/records/1
 
-Login as admin@invenio-software.org (password 123456) and view record 1 again:
+Login as admin@inveniosoftware.org (password 123456) and view record 1 again:
 
    http://localhost:5000/login
    http://localhost:5000/records/1
 
-Logout and login as reader@invenio-software.org (password 123456) and view
+Logout and login as reader@inveniosoftware.org (password 123456) and view
 record 1 again:
 
    http://localhost:5000/logout
@@ -85,12 +85,12 @@ InvenioAccess(app)
 def access():
     """Load access fixtures."""
     admin = accounts.datastore.create_user(
-        email='admin@invenio-software.org',
+        email='admin@inveniosoftware.org',
         password=encrypt_password('123456'),
         active=True,
     )
     reader = accounts.datastore.create_user(
-        email='reader@invenio-software.org',
+        email='reader@inveniosoftware.org',
         password=encrypt_password('123456'),
         active=True,
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ directory = invenio_records_ui/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_records_ui/translations/messages.pot
 

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(
     keywords='invenio records ui',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-records-ui',
     packages=packages,
     zip_safe=False,

--- a/tests/test_invenio_records_ui.py
+++ b/tests/test_invenio_records_ui.py
@@ -280,12 +280,12 @@ def test_permission(app):
     # Create admin
     with app.app_context():
         admin = accounts.datastore.create_user(
-            email='admin@invenio-software.org',
+            email='admin@inveniosoftware.org',
             password=encrypt_password('123456'),
             active=True,
         )
         reader = accounts.datastore.create_user(
-            email='reader@invenio-software.org',
+            email='reader@inveniosoftware.org',
             password=encrypt_password('123456'),
             active=True,
         )
@@ -313,7 +313,7 @@ def test_permission(app):
         res = client.get(record_url)
         assert res.status_code == 302
         res = client.post(login_url, data={
-            'email': 'admin@invenio-software.org', 'password': '123456'})
+            'email': 'admin@inveniosoftware.org', 'password': '123456'})
         assert res.status_code == 302
         res = client.get(record_url)
         res.status_code == 200
@@ -321,7 +321,7 @@ def test_permission(app):
     # Access record 1 as reader
     with app.test_client() as client:
         res = client.post(login_url, data={
-            'email': 'reader@invenio-software.org', 'password': '123456'})
+            'email': 'reader@inveniosoftware.org', 'password': '123456'})
         assert res.status_code == 302
         res = client.get(record_url)
         res.status_code == 403


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>