### PR TITLE
examples: addition of Flask-Menu and DB commit

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -49,5 +49,6 @@ recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs Makefile
 recursive-include examples *.py
+recursive-include examples *.txt
 recursive-include invenio_records_ui *.html
 recursive-include tests *.py

--- a/examples/app.py
+++ b/examples/app.py
@@ -30,10 +30,11 @@ Run example development server:
 .. code-block:: console
 
    $ cd examples
-   $ flask -a app.py db init
-   $ flask -a app.py db create
-   $ flask -a app.py fixtures records
-   $ flask -a app.py --debug run
+   $ export FLASK_APP=app.py
+   $ flask db init
+   $ flask db create
+   $ flask fixtures records
+   $ flask run --debugger
 
 View some records in your browser::
 
@@ -44,8 +45,6 @@ View some records in your browser::
    http://localhost:5000/records/5
    http://localhost:5000/records/6
    http://localhost:5000/records/7
-   http://localhost:5000/records/8
-   http://localhost:5000/records/9
 """
 
 from __future__ import absolute_import, print_function
@@ -72,8 +71,8 @@ if not os.path.exists(instance_dir):
 app = Flask(__name__, instance_path=instance_dir)
 app.config.update(dict(
     CELERY_ALWAYS_EAGER=True,
-    CELERY_RESULT_BACKEND="cache",
-    CELERY_CACHE_BACKEND="memory",
+    CELERY_RESULT_BACKEND='cache',
+    CELERY_CACHE_BACKEND='memory',
     CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
     # Disable access control
     RECORDS_UI_DEFAULT_PERMISSION_FACTORY=None
@@ -148,3 +147,5 @@ def records():
         # Record 7 - Unregistered PID
         PersistentIdentifier.create(
             'recid', '7', status=PIDStatus.RESERVED)
+
+    db.session.commit()

--- a/examples/app.py
+++ b/examples/app.py
@@ -30,6 +30,7 @@ Run example development server:
 .. code-block:: console
 
    $ cd examples
+   $ pip install -r requirements.txt
    $ export FLASK_APP=app.py
    $ flask db init
    $ flask db create

--- a/examples/permsapp.py
+++ b/examples/permsapp.py
@@ -30,6 +30,7 @@ Run example development server:
 .. code-block:: console
 
    $ cd examples
+   $ pip install -r requirements.txt
    $ export FLASK_APP=permsapp.py
    $ flask db init
    $ flask db create

--- a/examples/permsapp.py
+++ b/examples/permsapp.py
@@ -30,11 +30,12 @@ Run example development server:
 .. code-block:: console
 
    $ cd examples
-   $ flask -a permsapp.py db init
-   $ flask -a permsapp.py db create
-   $ flask -a permsapp.py fixtures records
-   $ flask -a permsapp.py fixtures access
-   $ flask -a permsapp.py --debug run
+   $ export FLASK_APP=permsapp.py
+   $ flask db init
+   $ flask db create
+   $ flask fixtures records
+   $ flask fixtures access
+   $ flask run --debugger
 
 Try to view record 1::
 
@@ -56,6 +57,7 @@ record 1 again:
 from __future__ import absolute_import, print_function
 
 from app import app, fixtures, rec1_uuid
+from flask_menu import Menu
 from flask_security.utils import encrypt_password
 from invenio_access import InvenioAccess
 from invenio_access.models import ActionUsers
@@ -78,6 +80,7 @@ app.config.update(
 accounts = InvenioAccounts(app)
 app.register_blueprint(blueprint)
 
+Menu(app)
 InvenioAccess(app)
 
 

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,6 @@
+Flask-CLI>=0.4.0
+Flask-Menu>=0.5.0
+Flask-Security>=1.7.5
+invenio-access>=1.0.0a8
+invenio-db>=1.0.0a10
+invenio-records-ui>=1.0.0a7


### PR DESCRIPTION
While investigating another issue in another package I needed to have a minimal application with records, record views, and permissions. The two examples here were what I needed, but required some tweaks to be run, which I'm sharing back.

On a different note, it would be very appreciated if the `examples` folder contained a `requirements.txt` file that a developer can `pip install -r` in a new virtualenv and have all the dependencies required to run the examples.