### PR TITLE
docs: removal of :undoc-members:

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -29,20 +29,16 @@ Flask extension
 ---------------
 
 .. automodule:: invenio_records_ui.ext
-   :members:
-   :undoc-members:
+   :members: InvenioRecordsUI, _RecordUIState
 
 Views
 -----
 
 .. automodule:: invenio_records_ui.views
    :members:
-   :undoc-members:
 
 Signals
 -------
 
 .. automodule:: invenio_records_ui.signals
    :members:
-   :undoc-members:
-


### PR DESCRIPTION
* Removes `:undoc-members:` flag causing early proxy evaluation of
  imported proxies.

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>