### PR TITLE
views: addition of record export

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,11 @@ language: python
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - python: "2.7"
+      env: REQUIREMENTS=devel SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio"
+    - python: "3.5"
+      env: REQUIREMENTS=devel SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio"
 
 cache:
   - pip

--- a/invenio_records_ui/config.py
+++ b/invenio_records_ui/config.py
@@ -40,9 +40,15 @@ RECORDS_UI_ENDPOINTS = {
         "pid_type": "recid",
         "route": "/records/<pid_value>",
         "template": "invenio_records_ui/detail.html",
+    },
+    "recid_export": {
+        "pid_type": "recid",
+        "route": "/records/<pid_value>/export/<format>",
+        "view_imp": "invenio_records_ui.views.export",
+        "template": "invenio_records_ui/export.html",
     }
 }
-"""Default UI endpoints loaded.
+"""Default UI endpoints.
 
 This option can be overwritten to describe the endpoints of the different
 record types.
@@ -94,4 +100,24 @@ The structure of the dictionary is as follows:
     (Default: ``invenio_records.api:Record``)
 
 :param methods: List of methods supported. (Default: ``['GET']``)
+"""
+
+RECORDS_UI_EXPORT_FORMATS = {}
+"""Defaut record serialization views.
+
+The structure of the dictionary is as follows:
+
+.. code-block:: python
+
+    RECORDS_UI_EXPORT_FORMATS = {
+        {"<pid-type>": {
+            "<format-slug>": {
+                "title": "<export format title>",
+                "serializer": "<object or import path to record serializer>",
+                "order": 1,
+            },
+            ...
+        },
+        ...
+    }
 """

--- a/invenio_records_ui/ext.py
+++ b/invenio_records_ui/ext.py
@@ -41,6 +41,18 @@ class _RecordUIState(object):
         """
         self.app = app
         self._permission_factory = None
+        self._export_formats = {}
+
+    def export_formats(self, pid_type):
+        """List of export formats."""
+        if pid_type not in self._export_formats:
+            fmts = self.app.config.get('RECORDS_UI_EXPORT_FORMATS', {}).get(
+                pid_type, {})
+            self._export_formats[pid_type] = sorted(
+                [(k, v) for k, v in fmts.items() if v],
+                key=lambda x: x[1]['order'],
+            )
+        return self._export_formats[pid_type]
 
     @property
     def permission_factory(self):

--- a/invenio_records_ui/signals.py
+++ b/invenio_records_ui/signals.py
@@ -24,6 +24,8 @@
 
 """Record module signals."""
 
+from __future__ import absolute_import, print_function
+
 from blinker import Namespace
 
 _signals = Namespace()

--- a/invenio_records_ui/templates/invenio_records_ui/export.html
+++ b/invenio_records_ui/templates/invenio_records_ui/export.html
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
+{# -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -21,24 +21,14 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
+-#}
 
-"""Utility."""
+{%- extends "invenio_records_ui/detail.html" %}
 
-from __future__ import absolute_import, print_function
+{%- set canonical_url = url_for('invenio_records_ui.recid', pid_value=pid.pid_value) %}
 
-import six
-from werkzeug.utils import import_string
+{% block record_body %}
+<h3 itemprop="name"> {{ format_title }} Export</h3>
+<pre style="white-space: pre-wrap;">{{data}}</pre>
+{% endblock record_body %}
 
-
-def obj_or_import_string(value, default=None):
-    """Import string or return object.
-
-    :params value: Import path or class object to instantiate.
-    :params default: Default object to return if the import fails.
-    :returns: The imported object.
-    """
-    if isinstance(value, six.string_types):
-        return import_string(value)
-    elif value:
-        return value
-    return default

--- a/invenio_records_ui/templates/invenio_records_ui/export_well.html
+++ b/invenio_records_ui/templates/invenio_records_ui/export_well.html
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
+{# -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -21,24 +21,13 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-
-"""Utility."""
-
-from __future__ import absolute_import, print_function
-
-import six
-from werkzeug.utils import import_string
-
-
-def obj_or_import_string(value, default=None):
-    """Import string or return object.
-
-    :params value: Import path or class object to instantiate.
-    :params default: Default object to return if the import fails.
-    :returns: The imported object.
-    """
-    if isinstance(value, six.string_types):
-        return import_string(value)
-    elif value:
-        return value
-    return default
+-#}
+{%- set formats = export_formats(pid.pid_type) %}
+{%- if formats %}
+<dt>{{_('Export')}}</dt>
+<ul class="list-inline">
+  {%- for slug, fmt in formats %}
+  <li><a href="{{ url_for('invenio_records_ui.recid_export', pid_value=pid.pid_value, format=slug) }}">{{fmt['title']}}</a></li>
+  {%- endfor %}
+</ul>
+{%- endif %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@
 
 from __future__ import absolute_import, print_function
 
+import json
 import os
 
 import pytest
@@ -37,6 +38,20 @@ from invenio_db import InvenioDB, db
 from invenio_files_rest import InvenioFilesREST
 from invenio_pidstore import InvenioPIDStore
 from invenio_records import InvenioRecords
+
+
+class DefaultJSONSerializer(object):
+
+    """Simple JSON serializer for testing."""
+
+    def serialize(self, pid, record):
+        """Serialize object to JSON.
+
+        :param pid: Persistent Identifier.
+        :param record: The :class:`invenio_records.api.Record` instance.
+        """
+        return json.dumps(record, sort_keys=True,
+                          indent=2, separators=(',', ': '))
 
 
 @pytest.fixture()
@@ -70,3 +85,8 @@ def app(request):
 
     request.addfinalizer(finalize)
     return app
+
+
+@pytest.fixture()
+def json_v1():
+    return DefaultJSONSerializer()

--- a/tests/test_invenio_records_ui.py
+++ b/tests/test_invenio_records_ui.py
@@ -308,3 +308,50 @@ def test_permission(app):
     with app.test_client() as client:
         res = client.get(record_url)
         res.status_code == 403
+
+
+def test_record_export(app, json_v1):
+    """Test record export formats."""
+    app.config.update(dict(
+        RECORDS_UI_EXPORT_FORMATS=dict(
+            recid=dict(
+                json=dict(
+                    title='JSON',
+                    serializer=json_v1,
+                    order=1,
+                )
+            )
+        )
+    ))
+
+    InvenioRecordsUI(app)
+    setup_record_fixture(app)
+
+    with app.test_client() as client:
+        res = client.get('/records/1/export/json')
+        assert res.status_code == 200
+        res = client.get('/records/1/export/None')
+        assert res.status_code == 404
+
+
+def test_default_export_format(app, json_v1):
+    """Test default configuration for record export format"""
+    from invenio_records_ui.ext import _RecordUIState
+
+    app.config.update(dict(
+        RECORDS_UI_EXPORT_FORMATS=dict(
+            recid=dict(
+                json=dict(
+                    title='JSON',
+                    serializer='fictitious_json_serializer',
+                    order=1,
+                )
+            )
+        )
+    ))
+
+    record_ui_state = _RecordUIState(app)
+    default_format = [('json', {'title': 'JSON',
+                                'serializer': 'fictitious_json_serializer',
+                                'order': 1})]
+    assert default_format == record_ui_state.export_formats('recid')


### PR DESCRIPTION
* Adds export options JSON, MARCXML, MODS and DublinCore
   in record detail page.

* Adds templates for export page and export options.
  (blocked by [#53](https://github.com/inveniosoftware/invenio-marc21/pull/53))

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>