### PR TITLE
global: load blueprints from entrypoint

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -61,6 +61,7 @@ from invenio_pidstore import InvenioPIDStore
 from invenio_records import InvenioRecords
 
 from invenio_records_ui import InvenioRecordsUI
+from invenio_records_ui.views import create_blueprint_from_app
 
 # create application's instance directory. Needed for this example only.
 current_dir = os.path.dirname(os.path.realpath(__file__))
@@ -87,6 +88,7 @@ InvenioDB(app)
 InvenioPIDStore(app)
 InvenioRecords(app)
 InvenioRecordsUI(app)
+app.register_blueprint(create_blueprint_from_app(app))
 
 
 rec1_uuid = 'deadbeef-1234-5678-ba11-b100dc0ffee5'

--- a/invenio_records_ui/__init__.py
+++ b/invenio_records_ui/__init__.py
@@ -76,11 +76,14 @@ variables in the template context:
 Installing endpoints
 ~~~~~~~~~~~~~~~~~~~~
 We have now configured which endpoint we want, so we can go ahead and install
-the extension (note, in this example we switch off the permission checking
-capabilities by setting ``RECORDS_UI_DEFAULT_PERMISSION_FACTORY`` to ``None``):
+the extension and register the endpoints (note, in this example we switch off
+the permission checking capabilities by setting
+``RECORDS_UI_DEFAULT_PERMISSION_FACTORY`` to ``None``):
 
+>>> from invenio_records_ui.views import create_blueprint_from_app
 >>> app.config['RECORDS_UI_DEFAULT_PERMISSION_FACTORY'] = None
 >>> ext_records_ui = InvenioRecordsUI(app)
+>>> app.register_blueprint(create_blueprint_from_app(app))
 
 In order for the following examples to work, you need to work within an
 Flask application context so let's push one:

--- a/invenio_records_ui/ext.py
+++ b/invenio_records_ui/ext.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import, print_function
 
 from . import config
 from .utils import obj_or_import_string
-from .views import create_blueprint
 
 
 class _RecordUIState(object):
@@ -68,11 +67,6 @@ class InvenioRecordsUI(object):
         :param app: The Flask application.
         """
         self.init_config(app)
-
-        # Register records blueprints
-        app.register_blueprint(
-            create_blueprint(app.config['RECORDS_UI_ENDPOINTS']))
-
         app.extensions['invenio-records-ui'] = _RecordUIState(app)
 
     def init_config(self, app):

--- a/invenio_records_ui/views.py
+++ b/invenio_records_ui/views.py
@@ -30,6 +30,21 @@ current_permission_factory = LocalProxy(
     lambda: current_app.extensions['invenio-records-ui'].permission_factory)
 
 
+def create_blueprint_from_app(app):
+    """Create Invenio-Records-UI blueprint from a Flask application.
+
+    .. note::
+
+        This function assumes that the application has loaded all extensions
+        that want to register REST endpoints via the ``RECORDS_UI_ENDPOINTS``
+        configuration variable.
+
+    :params app: A Flask application.
+    :returns: Configured blueprint.
+    """
+    return create_blueprint(app.config.get('RECORDS_UI_ENDPOINTS'))
+
+
 def create_blueprint(endpoints):
     """Create Invenio-Records-UI blueprint.
 

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,10 @@ setup(
         'invenio_base.apps': [
             'invenio_records_ui = invenio_records_ui:InvenioRecordsUI',
         ],
+        'invenio_base.blueprints': [
+            ('invenio_records_ui = '
+             'invenio_records_ui.views:create_blueprint_from_app'),
+        ],
         'invenio_i18n.translations': [
             'messages = invenio_records_ui',
         ],

--- a/tests/test_invenio_records_ui.py
+++ b/tests/test_invenio_records_ui.py
@@ -26,6 +26,7 @@ from invenio_records.api import Record
 
 from invenio_records_ui import InvenioRecordsUI
 from invenio_records_ui.signals import record_viewed
+from invenio_records_ui.views import create_blueprint_from_app
 
 
 def setup_record_fixture(app):
@@ -85,18 +86,21 @@ def test_init():
     """Test extension initialization."""
     app = Flask('testapp')
     ext = InvenioRecordsUI(app)
+    app.register_blueprint(create_blueprint_from_app(app))
     assert 'invenio-records-ui' in app.extensions
 
     app = Flask('testapp')
     ext = InvenioRecordsUI()
     assert 'invenio-records-ui' not in app.extensions
     ext.init_app(app)
+    app.register_blueprint(create_blueprint_from_app(app))
     assert 'invenio-records-ui' in app.extensions
 
 
 def test_view(app):
     """Test view."""
     InvenioRecordsUI(app)
+    app.register_blueprint(create_blueprint_from_app(app))
     setup_record_fixture(app)
 
     with app.test_client() as client:
@@ -130,6 +134,7 @@ def test_view(app):
 def test_signal(app):
     """Test view."""
     InvenioRecordsUI(app)
+    app.register_blueprint(create_blueprint_from_app(app))
     setup_record_fixture(app)
 
     called = {'record-viewed': False}
@@ -167,6 +172,7 @@ def test_changed_views(app):
         )
     ))
     InvenioRecordsUI(app)
+    app.register_blueprint(create_blueprint_from_app(app))
     setup_record_fixture(app)
 
     with app.test_client() as client:
@@ -217,6 +223,7 @@ def test_custom_view_method(app):
         )
     ))
     InvenioRecordsUI(app)
+    app.register_blueprint(create_blueprint_from_app(app))
     setup_record_fixture(app)
 
     with app.test_client() as client:
@@ -254,6 +261,7 @@ def test_permission(app):
     )
     Menu(app)
     InvenioRecordsUI(app)
+    app.register_blueprint(create_blueprint_from_app(app))
     accounts = InvenioAccounts(app)
     app.register_blueprint(accounts_blueprint)
     InvenioAccess(app)
@@ -309,6 +317,7 @@ def test_record_export(app, json_v1):
     ))
 
     InvenioRecordsUI(app)
+    app.register_blueprint(create_blueprint_from_app(app))
     setup_record_fixture(app)
 
     with app.test_client() as client:


### PR DESCRIPTION
* Introduces an "invenio_base.blueprints" entrypoint to load UI
  blueprints via a function. (closes #81)