### PR TITLE
fix: setuptools require underscores instead of dashes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,22 +64,22 @@ add_ignore = D401
 
 [compile_catalog]
 directory = invenio_records_ui/translations/
-use-fuzzy = True
+use_fuzzy = True
 
 [extract_messages]
 copyright_holder = CERN
 msgid_bugs_address = info@inveniosoftware.org
-mapping-file = babel.ini
-output-file = invenio_records_ui/translations/messages.pot
-add-comments = NOTE
+mapping_file = babel.ini
+output_file = invenio_records_ui/translations/messages.pot
+add_comments = NOTE
 
 [init_catalog]
-input-file = invenio_records_ui/translations/messages.pot
-output-dir = invenio_records_ui/translations/
+input_file = invenio_records_ui/translations/messages.pot
+output_dir = invenio_records_ui/translations/
 
 [update_catalog]
-input-file = invenio_records_ui/translations/messages.pot
-output-dir = invenio_records_ui/translations/
+input_file = invenio_records_ui/translations/messages.pot
+output_dir = invenio_records_ui/translations/
 
 [isort]
 profile=black


### PR DESCRIPTION
### Description

i18n: removed deprecated messages
fix: setuptools require underscores instead of dashes

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.

